### PR TITLE
add infrastructure for performance collectors

### DIFF
--- a/src/Microsoft.AspNet.StressFramework/Collectors/CpuTime.cs
+++ b/src/Microsoft.AspNet.StressFramework/Collectors/CpuTime.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.AspNet.StressFramework
+{
+    public class CpuTime
+    {
+        public TimeSpan KernelTime { get; }
+        public TimeSpan UserTime { get; }
+
+        public CpuTime(TimeSpan kernelTime, TimeSpan userTime)
+        {
+            KernelTime = kernelTime;
+            UserTime = userTime;
+        }
+
+        public static CpuTime Capture()
+        {
+            var me = Process.GetCurrentProcess();
+            return new CpuTime(
+                me.PrivilegedProcessorTime,
+                me.UserProcessorTime);
+        }
+
+        public override string ToString()
+        {
+            return $"K: {KernelTime}; U: {UserTime}";
+        }
+    }
+}

--- a/src/Microsoft.AspNet.StressFramework/Collectors/CpuTimeCollectorAttribute.cs
+++ b/src/Microsoft.AspNet.StressFramework/Collectors/CpuTimeCollectorAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Microsoft.AspNet.StressFramework.Collectors
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class CpuTimeCollectorAttribute : Attribute, ICollector
+    {
+        public void Initialize()
+        {
+
+        }
+
+        public void BeginIteration(StressTestIterationContext iteration)
+        {
+            iteration.Record(CpuTime.Capture());
+        }
+
+        public void EndIteration(StressTestIterationContext iteration)
+        {
+            iteration.Record(CpuTime.Capture());
+        }
+    }
+}

--- a/src/Microsoft.AspNet.StressFramework/Collectors/DataPoint.cs
+++ b/src/Microsoft.AspNet.StressFramework/Collectors/DataPoint.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.StressFramework.Collectors
+{
+    public class DataPoint
+    {
+        private DataPoint(DateTime timestampUtc, object value)
+        {
+            TimestampUtc = timestampUtc;
+            Value = value;
+        }
+
+        public DateTime TimestampUtc { get; }
+        public object Value { get; }
+
+        public static DataPoint Create(object value)
+        {
+            return new DataPoint(DateTime.UtcNow, value);
+        }
+
+        public override string ToString()
+        {
+            return $"[{TimestampUtc.ToLocalTime().ToString("O")}] {Value}";
+        }
+    }
+}

--- a/src/Microsoft.AspNet.StressFramework/Collectors/ICollector.cs
+++ b/src/Microsoft.AspNet.StressFramework/Collectors/ICollector.cs
@@ -1,0 +1,20 @@
+namespace Microsoft.AspNet.StressFramework.Collectors
+{
+    public interface ICollector
+    {
+        /// <summary>
+        /// Called by the stress framework to initialize the collector, before any iterations have been run
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
+        /// Called by the stress framework before a non-warmup iteration is executed.
+        /// </summary>
+        void BeginIteration(StressTestIterationContext context);
+
+        /// <summary>
+        /// Called by the stress framework after a non-warmup iteration is executed.
+        /// </summary>
+        void EndIteration(StressTestIterationContext context);
+    }
+}

--- a/src/Microsoft.AspNet.StressFramework/Collectors/MemorySnapshot.cs
+++ b/src/Microsoft.AspNet.StressFramework/Collectors/MemorySnapshot.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.AspNet.StressFramework
+{
+    public class MemorySnapshot
+    {
+        public long HeapMemoryBytes { get; }
+        public long WorkingSet { get; }
+        public long PrivateBytes { get; }
+
+        public MemorySnapshot(long heapMemoryBytes, long workingSet, long privateBytes)
+        {
+            HeapMemoryBytes = heapMemoryBytes;
+            WorkingSet = workingSet;
+            PrivateBytes = privateBytes;
+        }
+
+        public static MemorySnapshot Capture()
+        {
+            var me = Process.GetCurrentProcess();
+            return new MemorySnapshot(
+                GC.GetTotalMemory(forceFullCollection: false),
+                me.WorkingSet64,
+                me.PrivateMemorySize64);
+        }
+
+        public override string ToString()
+        {
+            return $"Heap: {HeapMemoryBytes / 1024.0:0.00}KB, WorkingSet: {WorkingSet / 1024.0:0.00}KB, Private: {PrivateBytes / 1024.0:0.00}KB";
+        }
+    }
+}

--- a/src/Microsoft.AspNet.StressFramework/Collectors/TotalMemoryCollectorAttribute.cs
+++ b/src/Microsoft.AspNet.StressFramework/Collectors/TotalMemoryCollectorAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Microsoft.AspNet.StressFramework.Collectors
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class TotalMemoryCollectorAttribute : Attribute, ICollector
+    {
+        public void Initialize()
+        {
+
+        }
+
+        public void BeginIteration(StressTestIterationContext iteration)
+        {
+            iteration.Record(MemorySnapshot.Capture());
+        }
+
+        public void EndIteration(StressTestIterationContext iteration)
+        {
+            iteration.Record(MemorySnapshot.Capture());
+        }
+    }
+}

--- a/src/Microsoft.AspNet.StressFramework/StressTestIterationContext.cs
+++ b/src/Microsoft.AspNet.StressFramework/StressTestIterationContext.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNet.StressFramework.Collectors;
+
+namespace Microsoft.AspNet.StressFramework
+{
+    public class StressTestIterationContext
+    {
+        private IList<ICollector> _collectors;
+        private List<DataPoint> _recordings = new List<DataPoint>();
+        private Stopwatch _stopwatch;
+
+        public StressTestIterationContext(IList<ICollector> collectors)
+        {
+            _collectors = collectors;
+        }
+
+        /// <summary>
+        /// Record a data point
+        /// </summary>
+        public void Record<T>(T data)
+        {
+            var dataPoint = DataPoint.Create(data);
+            _recordings.Add(dataPoint);
+        }
+
+        public void BeginIteration()
+        {
+            foreach (var collector in _collectors)
+            {
+                collector.BeginIteration(this);
+            }
+
+            _stopwatch = Stopwatch.StartNew();
+        }
+
+        public void EndIteration()
+        {
+            _stopwatch.Stop();
+
+            foreach (var collector in _collectors)
+            {
+                collector.EndIteration(this);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Stress.Tests/SmokeTest.cs
+++ b/test/Microsoft.AspNet.Stress.Tests/SmokeTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.StressFramework;
+using Microsoft.AspNet.StressFramework.Collectors;
 using Microsoft.AspNet.WebUtilities;
 using Xunit;
 
@@ -14,6 +15,7 @@ namespace Microsoft.AspNet.Stress.Tests
     public class SmokeTest
     {
         [StressTest]
+        [TotalMemoryCollector]
         public void SmokeyMcSmokeTest()
         {
             Assert.True(true);


### PR DESCRIPTION
To do still: Sampling, somewhere to actually write these objects :). I did a quick test by injecting a Console.WriteLine in the `StressTestIterationContext.Report` method and it is running the things correctly.

/cc @pranavkm @rynowak @NTaylorMullen 
